### PR TITLE
Hotfix: userData job, name 중복 저장 문제 해결 

### DIFF
--- a/src/pages/NameInputPage.jsx
+++ b/src/pages/NameInputPage.jsx
@@ -44,6 +44,7 @@ const NameInputPage = ({ onNext }) => {
     // 유효한 입력이 있는 경우
     setIsAnimating(true);
     setStoreName(name); // Zustand에 이름 저장
+    console.log("userData 업데이트:", { name }); // 이름 저장 로그 추가
     
     // 애니메이션 효과 후 다음 페이지로
     setTimeout(() => {

--- a/src/pages/NameInputPage.jsx
+++ b/src/pages/NameInputPage.jsx
@@ -44,7 +44,6 @@ const NameInputPage = ({ onNext }) => {
     // 유효한 입력이 있는 경우
     setIsAnimating(true);
     setStoreName(name); // Zustand에 이름 저장
-    console.log("userData 업데이트:", { name }); // 이름 저장 로그 추가
     
     // 애니메이션 효과 후 다음 페이지로
     setTimeout(() => {

--- a/src/pages/UserInputPage.jsx
+++ b/src/pages/UserInputPage.jsx
@@ -68,7 +68,7 @@ const UserInputPage = () => {
     
     try {
       // 직업은 userData에 저장
-      setUserData({ job, name: job }); // name 필드도 추가 (이름 표시용)
+      setUserData({ job});
 
       // 사진 배경 제거 API 호출 (이제 항상 실행됨)
       console.log("배경 제거 API 호출"); // 디버깅용


### PR DESCRIPTION
## 📌 PR 제목 규칙
- [x] : Hotfix: 긴급 수정사항 반영 및 에러 해결
---

## 📢 PR 개요  
- userData 에서 name이 job과 동일한 value 로  할당되어, 프로필 카드 생성시 상단부에 직업이 들어가는 문제를 해결했습니다

---

## 🏷 관련 이슈
🔗 **Closes** #29

---

## 📂 변경 사항  
❌ **제거된 기능:**  
- [x] 잘못된 코드 삭제  
---

## 📸 스크린샷 (선택)  
BEFORE
이름을 입력해도 이름의 value 가 job 이 되어버림
<img width="298" alt="Screenshot 2025-04-06 at 12 16 17 AM" src="https://github.com/user-attachments/assets/3f8d41d1-950c-4867-a575-82d88fc7f78e" />


AFTER
이름 데이터 유지
<img width="312" alt="Screenshot 2025-04-06 at 12 23 30 AM" src="https://github.com/user-attachments/assets/5077a571-086b-4243-aa3c-098e6ec3156e" />


---

## ✅ 체크리스트  
- [x] PR 제목 규칙을 지켰나요?  
- [x] 코드가 정상적으로 동작하나요?  
- [x] 충돌(conflict)이 발생하지 않나요?  
- [x] PR이 작은 단위로 나뉘어 있나요?  

---

## 📢 리뷰 참고 사항  
> (리뷰어에게 필요한 추가 정보가 있다면 작성해주세요.)
- hotfix입니다